### PR TITLE
Export DeviceStats properties and add calculation methods

### DIFF
--- a/driver/ixgbe.go
+++ b/driver/ixgbe.go
@@ -362,10 +362,10 @@ func (dev *ixgbeDevice) ReadStats(stats *DeviceStats) {
 	txBytes := uint64(getReg32(dev.addr, IXGBE_GOTCL)) | uint64(getReg32(dev.addr, IXGBE_GOTCH))<<32
 	//rxDmaPkts := getReg32(dev.addr, IXGBE_RXDGPC)
 	if stats != nil {
-		stats.rxPackets += uint64(rxPkts)
-		stats.txPackets += uint64(txPkts)
-		stats.rxBytes += rxBytes
-		stats.txBytes += txBytes
+		stats.RXPackets += uint64(rxPkts)
+		stats.TXPackets += uint64(txPkts)
+		stats.RXBytes += rxBytes
+		stats.TXBytes += txBytes
 		//stats.rxDmaPackets += uint64(rxDmaPkts)
 	}
 }


### PR DESCRIPTION
First off: thanks a lot for this driver! 

This PR exposes the DeviceStats so users of the library can use it directly:

- Allow access to the RX/TX Bytes/Packets counters directly.
- Add simple calculation methods to DeviceStats (and use them in the printing functions).

Everything should be backwards compatible.